### PR TITLE
스프링 시큐리티 AuthenticationPrincipal 카테고리를 수정하라

### DIFF
--- a/_wiki/spring-security/authentication-principal.md
+++ b/_wiki/spring-security/authentication-principal.md
@@ -7,7 +7,7 @@ author  : 한윤석
 tag     : 
 toc     : true
 public  : true
-parent  : scrum
+parent  : spring-security
 latex   : false
 ---
 * TOC


### PR DESCRIPTION
해당 내용이 카테고리가 스프링 시큐리티가 아닌 스크럼으로 되어
있었습니다.
![스프링 시큐리티에서 @AuthenticationPrincipal를 쓰면 안 되는 이유 - 코드숨 기술블로그 2023-01-03 11-12-14](https://user-images.githubusercontent.com/68071599/210292047-920ffb1a-ba07-4224-bd47-a00dcfe7e2e8.jpg)


내용에 맞게 스프링 시큐리티로 변경했습니다.

